### PR TITLE
feat(dashboard): mobile quick-add FAB + fix expenses export button

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -158,6 +158,18 @@
         </div>
       </div>
     </div>
+
+    <!-- Mobile quick-add FAB (sits above the layout's GitHub button) -->
+    <NuxtLink
+      to="/transactions/add"
+      class="md:hidden fixed bottom-24 right-6 z-50 flex items-center gap-2 bg-primary text-white pl-4 pr-5 py-4 rounded-full shadow-lg shadow-primary/30 active:scale-95 transition-all border border-white/10"
+      aria-label="Ajouter une dépense"
+    >
+      <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
+      </svg>
+      <span class="text-sm font-bold whitespace-nowrap">Dépense</span>
+    </NuxtLink>
   </div>
 </template>
 

--- a/app/pages/transactions/index.vue
+++ b/app/pages/transactions/index.vue
@@ -2,7 +2,7 @@
   <div class="flex flex-col gap-6 lg:gap-10 min-w-0 mx-auto max-w-[1200px] w-full pb-20">
 
     <!-- Header Section -->
-    <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-6 overflow-hidden">
+    <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-6">
       <div>
         <h1 class="text-3xl font-bold text-text-heading tracking-tight mb-2">Dépenses</h1>
         <p class="text-text-body/60 font-medium">Vue d'ensemble et historique de toutes vos transactions.</p>


### PR DESCRIPTION
- Add a mobile-only floating "+ Dépense" button on the dashboard for quick access to /transactions/add, positioned above the layout's GitHub FAB.
- Fix the export (download) button on the Dépenses page: the header had overflow-hidden, which clipped the absolutely-positioned export dropdown so it opened but was invisible/unclickable. Removed overflow-hidden.