### PR TITLE
docs: add token-optimized CLAUDE.md and path-scoped rules

### DIFF
--- a/.claude/rules/app-frontend.md
+++ b/.claude/rules/app-frontend.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - "app/**/*.vue"
+  - "app/**/*.ts"
+---
+# app/ — Nuxt frontend
+
+- Vue 3 Composition API, `<script setup lang="ts">` only. Typed `defineProps`/`defineEmits`.
+- Pages are file-based routes under `app/pages/`; nested dirs = nested paths, `[param]` = dynamic.
+- Protect pages with `definePageMeta({ middleware: 'auth' })`; auth state via `useUserSession()`.
+- Rely on Nuxt auto-imports — do not manually import `ref`, `computed`, `useState`, composables, or `#components`.
+- Shared cross-component state: `useState(key, init)` inside a `composables/use*.ts`.
+- Reusable UI in `app/components/ui/` (Button, Input) with `variant` props; reuse before adding new ones.
+- Styling: Tailwind 4 utility classes inline. Theme tokens: `bg-primary`, `text-primary`, `bg-primary-light`.
+- Fetch data with `$fetch`/`useFetch` against `/api/...`. Display money by dividing cents by 100.

--- a/.claude/rules/server-api.md
+++ b/.claude/rules/server-api.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - "server/**/*.ts"
+---
+# server/ — Nitro API & DB
+
+- Files: `server/api/<resource>/<name>.<method>.ts`. Method is inferred from the suffix (`.get.ts`, `.post.ts`, `.patch.ts`, `.delete.ts`). Dynamic params: `[id].method.ts`.
+- Auth first in every handler: `const session = await getUserSession(event)`; if `!session.user` → `throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })`. Cast user: `session.user as { id: number }`.
+- Always scope reads/writes/deletes by `userId` to prevent cross-user access.
+- Validate required fields from `readBody(event)`; on missing → `createError({ statusCode: 400, ... })`.
+- Use `db`, `fetchOne`, `fetchAll` from `~/server/utils/db.ts`. Never `.all()`/`.get()` directly.
+- Insert/update returning a row: `await fetchOne(db.insert(table as any).values({...} as any).returning())`.
+- Money fields: convert to cents on write (`Math.round(amount * 100)`), expect cents on read.
+- Schema edits in `database/schema.ts` only via the dual-dialect helpers; then `db:generate` + `db:push`.
+- Sensitive routes apply stricter rate limits via `defineRateLimit` in-handler (global cap is in `middleware/rateLimit.ts`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md
+
+## Stack
+Nuxt 4 (Vue 3, Nitro) + TypeScript. Tailwind CSS 4. Drizzle ORM (SQLite local / Postgres prod). Auth: nuxt-auth-utils. Validation: zod. Runtime: Node 22+, npm.
+
+## Commands
+- dev: `npm run dev`
+- build: `npm run build`
+- db push schema: `npm run db:push`
+- db gen migration: `npm run db:generate`
+- db studio: `npm run db:studio`
+- typecheck: `npx nuxt typecheck`
+
+## Structure
+- `app/`: Nuxt frontend (auto-imported). Subdirs below.
+- `app/pages/`: file-based routes. `app/components/` + `app/components/ui/` (Button, Input).
+- `app/composables/`: shared state (useState). `app/middleware/auth.ts`: route guard.
+- `app/layouts/`, `app/assets/css/main.css`, `app/utils/` (e.g. exportData).
+- `server/api/`: Nitro endpoints, named `<resource>.<method>.ts` (e.g. `index.post.ts`).
+- `server/database/schema.ts`: dual-dialect Drizzle schema. `server/utils/db.ts`: `db`, `fetchOne`, `fetchAll`.
+- `server/middleware/`: global (rateLimit). `types/`: shared TS types + `auth.d.ts` (User session).
+
+## Rules
+- Money stored as integer cents. Multiply on write (`Math.round(amount * 100)`), divide on read.
+- Schema must stay dialect-agnostic: use the helpers in `schema.ts` (`text`, `int`, `real`, `dateColumn`, `idColumn`), never raw `sqliteTable`/`pgTable`.
+- DB queries: use `fetchOne`/`fetchAll` from `server/utils/db.ts`, never call `.all()`/`.get()` directly (Postgres lacks them).
+- Every API handler: guard with `getUserSession(event)` → 401 if no `session.user`; scope queries by `user.id`.
+- Validate/guard required body fields; throw `createError({ statusCode, statusMessage })`.
+- Frontend: `<script setup lang="ts">`, Composition API, typed `defineProps`. Tailwind utility classes only.
+- Prefer Nuxt auto-imports (no manual import of `ref`, `useState`, `db` helpers where auto-imported).
+- After schema changes run `npm run db:generate` (commit migration) then `npm run db:push`.
+
+## Never
+- Edit generated dirs: `.nuxt/`, `.output/`, `.nitro/`, `node_modules/`, `server/database/migrations/` (regenerate via drizzle-kit).
+- Touch `sqlite.db` or commit it; never commit `.env` or print secret values.
+- Hardcode a single DB dialect — both SQLite and Postgres must work.
+- Store/compare money as floats in the DB.


### PR DESCRIPTION
Add a concise root CLAUDE.md (stack, commands, structure, rules, never) to give Claude project context without re-deriving it each session.

Split fine-grained conventions into path-scoped rule files under .claude/rules/ so they only load when relevant:
- server-api.md (server/**/*.ts): Nitro handler/auth/DB patterns
- app-frontend.md (app/**): Vue 3 / Nuxt / Tailwind conventions