### PR TITLE
fix(server): verify category ownership on expense create/update

### DIFF
--- a/server/api/expenses/[id].patch.ts
+++ b/server/api/expenses/[id].patch.ts
@@ -15,6 +15,10 @@ export default defineEventHandler(async (event) => {
 
     const { categoryId, amount, merchant, date, note } = await validateBody(event, expenseUpdateSchema);
 
+    if (categoryId !== undefined) {
+        await assertCategoryOwned(categoryId, user.id);
+    }
+
     const updated = await fetchOne((db as any).update(expenses as any)
         .set({
             categoryId,

--- a/server/api/expenses/index.post.ts
+++ b/server/api/expenses/index.post.ts
@@ -5,6 +5,9 @@ export default defineEventHandler(async (event) => {
     const user = await requireAuth(event);
 
     const { categoryId, amount, merchant, date, note } = await validateBody(event, expenseCreateSchema);
+
+    await assertCategoryOwned(categoryId, user.id);
+
     const newExpense = await fetchOne(db.insert(expenses as any).values({
         userId: user.id,
         categoryId,

--- a/server/utils/ownership.ts
+++ b/server/utils/ownership.ts
@@ -1,0 +1,26 @@
+import { and, eq } from 'drizzle-orm';
+import { categories } from '../database/schema';
+import { db, fetchOne } from './db';
+
+/**
+ * Assert that the given category belongs to the user.
+ * Throws 400 if it does not exist or belongs to someone else — prevents
+ * attaching an expense to another user's category (cross-user data leak,
+ * since reads join categories on categoryId).
+ *
+ * Auto-imported by Nitro (like `requireAuth` / `validateBody`).
+ */
+export const assertCategoryOwned = async (categoryId: number, userId: number) => {
+    const category = await fetchOne(
+        db.select({ id: (categories as any).id })
+            .from(categories as any)
+            .where(and(eq((categories as any).id, categoryId), eq((categories as any).userId, userId))),
+    );
+
+    if (!category) {
+        throw createError({
+            statusCode: 400,
+            statusMessage: 'Invalid category',
+        });
+    }
+};


### PR DESCRIPTION
Corrige le point **N1** (faille d'isolation inter-utilisateurs).

## Problème

`POST /api/expenses` et `PATCH /api/expenses/:id` acceptaient un `categoryId` du body **sans vérifier qu'il appartient à l'utilisateur**. Comme la lecture (`GET /api/expenses`) fait un `JOIN` sur `categoryId`, un utilisateur pouvait rattacher une dépense à la catégorie d'un autre et **lire son nom / icône / couleur**. Les ids de catégorie étant des entiers séquentiels, ils sont devinables.

## Correctif

- Nouveau helper auto-importé `assertCategoryOwned(categoryId, userId)` dans `server/utils/ownership.ts` — lève **400 « Invalid category »** si la catégorie n'existe pas ou appartient à quelqu'un d'autre (même requête `id AND userId` que le check déjà utilisé dans `categories/[id].patch.ts`).
- Appelé **inconditionnellement** à la création, et **seulement si `categoryId` est fourni** à la mise à jour (PATCH partiel).

## Vérifications

- **Typecheck** : 76 vs 72 sur main. Les 4 deltas sont **du même type pré-existant** (TS2349/TS2554 dual-dialecte Drizzle) — `ownership.ts` réutilise le pattern `db.select().from(x as any)` commun à tous les handlers. **Aucun nouveau genre d'erreur**, aucune erreur fonctionnelle. Se résorbera avec le nettoyage `as any` (point B).
- Logique calquée sur un pattern d'ownership déjà éprouvé dans le repo.

## Note

Vérifié par typecheck + cohérence de pattern, **pas** par une requête live (pour ne pas polluer la base de dev avec des utilisateurs de test). Je peux faire un test e2e dédié sur une base jetable si tu le souhaites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)