### PR TITLE
Multi-device sessions with sliding expiration and revocation

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "vidi-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -137,6 +137,51 @@
           </button>
         </form>
       </div>
+
+      <!-- Devices Section -->
+      <div class="bg-card-inner rounded-[40px] p-8 lg:p-10 shadow-[0_8px_30px_rgb(0,0,0,0.02)] border border-[#eff3f1]">
+        <h2 class="text-xl font-bold text-text-heading mb-8 flex items-center gap-3">
+          <div class="w-10 h-10 rounded-xl bg-primary/10 text-primary flex items-center justify-center">
+            <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 17.25v1.007a3 3 0 01-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0115 18.257V17.25m6-12V15a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 15V5.25m18 0A2.25 2.25 0 0018.75 3H5.25A2.25 2.25 0 003 5.25m18 0V12a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 12V5.25" />
+            </svg>
+          </div>
+          Appareils connectés
+        </h2>
+
+        <div v-if="isLoadingSessions" class="text-text-body/60 font-medium py-4">Chargement…</div>
+
+        <div v-else-if="deviceSessions.length === 0" class="text-text-body/60 font-medium py-4">
+          Aucune session active.
+        </div>
+
+        <div v-else class="flex flex-col gap-4">
+          <div
+            v-for="s in deviceSessions"
+            :key="s.id"
+            class="flex items-center justify-between gap-4 bg-white border border-[#e3ece8] rounded-[22px] px-6 py-4"
+          >
+            <div class="flex flex-col gap-1 min-w-0">
+              <div class="flex items-center gap-2">
+                <span class="font-bold text-text-heading">{{ parseDevice(s.userAgent) }}</span>
+                <span v-if="s.current" class="text-[11px] font-bold uppercase tracking-wide text-primary bg-primary/10 px-2 py-0.5 rounded-full">
+                  Cet appareil
+                </span>
+              </div>
+              <span class="text-text-body/60 text-sm font-medium truncate">
+                {{ s.ipAddress || 'IP inconnue' }} · Actif {{ formatDate(s.lastActiveAt, { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' }) }}
+              </span>
+            </div>
+            <button
+              @click="revokeSession(s.id, s.current)"
+              :disabled="revokingSessionId === s.id"
+              class="shrink-0 px-5 py-3 rounded-[16px] font-bold text-sm text-red-500 bg-red-50 hover:bg-red-100 transition-colors disabled:opacity-50"
+            >
+              {{ s.current ? 'Se déconnecter' : 'Déconnecter' }}
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- Success Feedback Overlay -->
@@ -166,9 +211,23 @@ definePageMeta({
 
 const { user, fetch: fetchSession } = useUserSession();
 const currentUser = computed(() => user.value as { name?: string; email?: string } | null);
+const { formatDate } = useFormat();
 
 const isUpdatingProfile = ref(false);
 const isUpdatingPassword = ref(false);
+
+interface DeviceSession {
+  id: string;
+  userAgent: string | null;
+  ipAddress: string | null;
+  createdAt: string;
+  lastActiveAt: string;
+  current: boolean;
+}
+
+const deviceSessions = ref<DeviceSession[]>([]);
+const isLoadingSessions = ref(false);
+const revokingSessionId = ref<string | null>(null);
 
 const profileForm = reactive({
   name: currentUser.value?.name || ''
@@ -258,6 +317,54 @@ const updatePassword = async () => {
 watch(() => currentUser.value?.name, (newName) => {
   if (newName) profileForm.name = newName;
 }, { immediate: true });
+
+const parseDevice = (ua: string | null) => {
+  if (!ua) return 'Appareil inconnu';
+  const browser = /Edg\//.test(ua) ? 'Edge'
+    : /Chrome\//.test(ua) ? 'Chrome'
+    : /Firefox\//.test(ua) ? 'Firefox'
+    : /Safari\//.test(ua) ? 'Safari'
+    : 'Navigateur';
+  const os = /Windows/.test(ua) ? 'Windows'
+    : /Mac OS X/.test(ua) ? 'macOS'
+    : /Android/.test(ua) ? 'Android'
+    : /iPhone|iPad/.test(ua) ? 'iOS'
+    : /Linux/.test(ua) ? 'Linux'
+    : 'Système inconnu';
+  return `${browser} · ${os}`;
+};
+
+const loadSessions = async () => {
+  isLoadingSessions.value = true;
+  try {
+    const { sessions } = await $fetch('/api/user/sessions');
+    deviceSessions.value = sessions;
+  } catch (err: any) {
+    showFeedback(err.statusMessage || 'Impossible de charger les sessions.', true);
+  } finally {
+    isLoadingSessions.value = false;
+  }
+};
+
+const revokeSession = async (id: string, isCurrent: boolean) => {
+  if (revokingSessionId.value) return;
+  revokingSessionId.value = id;
+  try {
+    await $fetch(`/api/user/sessions/${id}`, { method: 'DELETE' });
+    if (isCurrent) {
+      await navigateTo('/login');
+      return;
+    }
+    deviceSessions.value = deviceSessions.value.filter((s) => s.id !== id);
+    showFeedback('Session déconnectée.');
+  } catch (err: any) {
+    showFeedback(err.statusMessage || 'Impossible de déconnecter cette session.', true);
+  } finally {
+    revokingSessionId.value = null;
+  }
+};
+
+onMounted(loadSessions);
 </script>
 
 <style scoped>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -5,6 +5,13 @@ export default defineNuxtConfig({
   devtools: { enabled: true },
   css: ['~/assets/css/main.css'],
   modules: ['nuxt-auth-utils'],
+  runtimeConfig: {
+    session: {
+      // Cookie lifetime; requireAuth slides this forward on active use and
+      // enforces per-device revocation via the `sessions` table.
+      maxAge: 60 * 60 * 24 * 30, // 30 days
+    },
+  },
   vite: {
     plugins: [
       tailwindcss(),

--- a/server/api/auth/login.post.ts
+++ b/server/api/auth/login.post.ts
@@ -1,6 +1,7 @@
 import { compare } from 'bcrypt';
+import { randomUUID } from 'node:crypto';
 import { eq } from 'drizzle-orm';
-import { users } from '../../database/schema';
+import { users, sessions } from '../../database/schema';
 import { db, fetchOne } from '../../utils/db';
 
 export default defineEventHandler(async (event) => {
@@ -27,7 +28,20 @@ export default defineEventHandler(async (event) => {
         });
     }
 
-    // Create session
+    // Create a device row so this session can be listed/revoked independently
+    // of any other device the user is logged in on.
+    const sessionId = randomUUID();
+    const now = new Date();
+    await db.insert(sessions as any).values({
+        id: sessionId,
+        userId: user.id,
+        userAgent: getHeader(event, 'user-agent') || null,
+        ipAddress: getRequestIP(event) || null,
+        createdAt: now,
+        lastActiveAt: now,
+        expiresAt: new Date(now.getTime() + SESSION_MAX_AGE_SECONDS * 1000),
+    } as any).execute();
+
     await setUserSession(event, {
         user: {
             id: user.id,
@@ -35,6 +49,7 @@ export default defineEventHandler(async (event) => {
             name: user.name,
             role: user.role,
         },
+        sessionId,
     });
 
     return {

--- a/server/api/auth/register.post.ts
+++ b/server/api/auth/register.post.ts
@@ -1,6 +1,7 @@
 import { hash } from 'bcrypt';
+import { randomUUID } from 'node:crypto';
 import { eq } from 'drizzle-orm';
-import { users, categories } from '../../database/schema';
+import { users, categories, sessions } from '../../database/schema';
 import { db, fetchOne } from '../../utils/db';
 
 export default defineEventHandler(async (event) => {
@@ -51,7 +52,20 @@ export default defineEventHandler(async (event) => {
         } as any).execute();
     }
 
-    // Create session
+    // Create a device row so this session can be listed/revoked independently
+    // of any other device the user is logged in on.
+    const sessionId = randomUUID();
+    const now = new Date();
+    await db.insert(sessions as any).values({
+        id: sessionId,
+        userId: newUser.id,
+        userAgent: getHeader(event, 'user-agent') || null,
+        ipAddress: getRequestIP(event) || null,
+        createdAt: now,
+        lastActiveAt: now,
+        expiresAt: new Date(now.getTime() + SESSION_MAX_AGE_SECONDS * 1000),
+    } as any).execute();
+
     await setUserSession(event, {
         user: {
             id: newUser.id,
@@ -59,6 +73,7 @@ export default defineEventHandler(async (event) => {
             name: newUser.name,
             role: newUser.role,
         },
+        sessionId,
     });
 
     return {

--- a/server/api/user/sessions.get.ts
+++ b/server/api/user/sessions.get.ts
@@ -1,0 +1,26 @@
+import { desc, eq } from 'drizzle-orm';
+import { sessions } from '../../database/schema';
+import { db, fetchAll } from '../../utils/db';
+
+export default defineEventHandler(async (event) => {
+    const user = await requireAuth(event);
+    const userSession = await getUserSession(event);
+
+    const sessionsAny = sessions as any;
+    const rows = await fetchAll(
+        db.select().from(sessionsAny)
+            .where(eq(sessionsAny.userId, user.id))
+            .orderBy(desc(sessionsAny.lastActiveAt)),
+    );
+
+    return {
+        sessions: rows.map((row: any) => ({
+            id: row.id,
+            userAgent: row.userAgent,
+            ipAddress: row.ipAddress,
+            createdAt: row.createdAt,
+            lastActiveAt: row.lastActiveAt,
+            current: row.id === userSession.sessionId,
+        })),
+    };
+});

--- a/server/api/user/sessions/[id].delete.ts
+++ b/server/api/user/sessions/[id].delete.ts
@@ -1,0 +1,38 @@
+import { and, eq } from 'drizzle-orm';
+import { sessions } from '../../../database/schema';
+import { db, fetchOne } from '../../../utils/db';
+
+export default defineEventHandler(async (event) => {
+    const user = await requireAuth(event);
+    const userSession = await getUserSession(event);
+
+    const id = getRouterParam(event, 'id');
+    if (!id) {
+        throw createError({
+            statusCode: 400,
+            statusMessage: 'Session id is required',
+        });
+    }
+
+    const sessionsAny = sessions as any;
+    const target = await fetchOne(
+        db.select().from(sessionsAny).where(and(eq(sessionsAny.id, id), eq(sessionsAny.userId, user.id))),
+    );
+
+    if (!target) {
+        throw createError({
+            statusCode: 404,
+            statusMessage: 'Session not found',
+        });
+    }
+
+    await db.delete(sessionsAny).where(eq(sessionsAny.id, id)).execute();
+
+    // Revoking the device we're currently on: clear its cookie immediately
+    // instead of waiting for the next request's requireAuth check to 401.
+    if (id === userSession.sessionId) {
+        await clearUserSession(event);
+    }
+
+    return { success: true };
+});

--- a/server/database/migrations/0002_add_session_device_tracking.sql
+++ b/server/database/migrations/0002_add_session_device_tracking.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "sessions" ALTER COLUMN "expires_at" SET DATA TYPE timestamp;--> statement-breakpoint
+ALTER TABLE "categories" ADD COLUMN "max_budget" integer;--> statement-breakpoint
+ALTER TABLE "sessions" ADD COLUMN "user_agent" text;--> statement-breakpoint
+ALTER TABLE "sessions" ADD COLUMN "ip_address" text;--> statement-breakpoint
+ALTER TABLE "sessions" ADD COLUMN "created_at" timestamp NOT NULL;--> statement-breakpoint
+ALTER TABLE "sessions" ADD COLUMN "last_active_at" timestamp NOT NULL;

--- a/server/database/migrations/meta/0001_snapshot.json
+++ b/server/database/migrations/meta/0001_snapshot.json
@@ -1,0 +1,384 @@
+{
+  "id": "8527c0fd-01ae-4fb5-abdf-a532f8c12b50",
+  "prevId": "54add19c-b448-46e9-9b04-c89bc7514948",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_budget": {
+          "name": "max_budget",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_user_id_users_id_fk": {
+          "name": "categories_user_id_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.expenses": {
+      "name": "expenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant": {
+          "name": "merchant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "expenses_user_id_users_id_fk": {
+          "name": "expenses_user_id_users_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "expenses_category_id_categories_id_fk": {
+          "name": "expenses_category_id_categories_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investments": {
+      "name": "investments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset": {
+          "name": "asset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "investments_user_id_users_id_fk": {
+          "name": "investments_user_id_users_id_fk",
+          "tableFrom": "investments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/database/migrations/meta/_journal.json
+++ b/server/database/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1772741942903,
       "tag": "0000_thankful_the_fallen",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1784206076567,
+      "tag": "0002_add_session_device_tracking",
+      "breakpoints": true
     }
   ]
 }

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -47,7 +47,11 @@ export const users = table('users', {
 export const sessions = table('sessions', {
     id: text('id').primaryKey(),
     userId: int('user_id').notNull().references(() => users.id),
-    expiresAt: int('expires_at').notNull(),
+    userAgent: text('user_agent'),
+    ipAddress: text('ip_address'),
+    createdAt: dateColumn('created_at').notNull().$defaultFn(() => new Date()),
+    lastActiveAt: dateColumn('last_active_at').notNull().$defaultFn(() => new Date()),
+    expiresAt: dateColumn('expires_at').notNull(),
 });
 
 export const categories = table('categories', {

--- a/server/plugins/sessionCleanup.ts
+++ b/server/plugins/sessionCleanup.ts
@@ -1,0 +1,15 @@
+import { eq } from 'drizzle-orm';
+import { sessions } from '../database/schema';
+import { db } from '../utils/db';
+
+// Runs on every clearUserSession() call, regardless of entry point (our
+// /api/auth/logout, or the built-in /api/_auth/session DELETE route used by
+// useUserSession().clear() in TheSidebar.vue) — deletes the matching device
+// row so a cleared cookie can't be confused with a still-valid session.
+export default defineNitroPlugin(() => {
+    sessionHooks.hook('clear', async (session) => {
+        const sessionId = session.sessionId;
+        if (!sessionId) return;
+        await db.delete(sessions as any).where(eq((sessions as any).id, sessionId)).execute();
+    });
+});

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -1,4 +1,7 @@
 import type { H3Event } from 'h3';
+import { eq } from 'drizzle-orm';
+import { sessions } from '../database/schema';
+import { db, fetchOne } from './db';
 
 /**
  * Shape of the authenticated user stored in the session.
@@ -12,21 +15,65 @@ export interface SessionUser {
     role: string;
 }
 
+// Must match nuxt.config.ts `runtimeConfig.session.maxAge`. Also used as the
+// sliding window written to `sessions.expiresAt` on login and on renewal.
+export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 30; // 30 days
+
+// How long a device can stay idle before its next request pays the cost of
+// renewing the DB row + resealing the cookie (avoids a write on every request).
+const SESSION_RENEW_THRESHOLD_MS = 1000 * 60 * 60 * 24; // 1 day
+
 /**
  * Require an authenticated user.
- * Throws 401 if there is no session user. Returns the typed session user
- * (`{ id, email, name, role }`) so handlers don't need to re-cast it.
+ * Throws 401 if there is no session, or if the session's device row was
+ * revoked/expired server-side (logout-elsewhere, "end session" from another
+ * device, or the sliding window lapsing from inactivity).
+ * On success, slides the session forward if it's getting old.
+ * Returns the typed session user (`{ id, email, name, role }`) so handlers
+ * don't need to re-cast it.
  *
  * Auto-imported by Nitro (like `defineRateLimit` / `validateBody`).
  */
 export const requireAuth = async (event: H3Event): Promise<SessionUser> => {
     const session = await getUserSession(event);
-    if (!session.user) {
+    if (!session.user || !session.sessionId) {
         throw createError({
             statusCode: 401,
             statusMessage: 'Unauthorized',
         });
     }
+
+    const sessionsAny = sessions as any;
+    const dbSession = await fetchOne(
+        db.select().from(sessionsAny).where(eq(sessionsAny.id, session.sessionId)),
+    );
+
+    if (!dbSession || dbSession.expiresAt.getTime() < Date.now()) {
+        await clearUserSession(event);
+        throw createError({
+            statusCode: 401,
+            statusMessage: 'Unauthorized',
+        });
+    }
+
+    const now = new Date();
+    if (now.getTime() - dbSession.lastActiveAt.getTime() > SESSION_RENEW_THRESHOLD_MS) {
+        const newExpiresAt = new Date(now.getTime() + SESSION_MAX_AGE_SECONDS * 1000);
+        await (db as any)
+            .update(sessionsAny)
+            .set({ lastActiveAt: now, expiresAt: newExpiresAt })
+            .where(eq(sessionsAny.id, session.sessionId))
+            .execute();
+
+        // Reseal the cookie too: h3 pins the cookie's own expiry to its
+        // creation time, so only replaceUserSession (not setUserSession)
+        // actually pushes it forward.
+        await replaceUserSession(event, {
+            user: session.user,
+            sessionId: session.sessionId,
+        });
+    }
+
     return session.user as SessionUser;
 };
 

--- a/types/auth.d.ts
+++ b/types/auth.d.ts
@@ -7,7 +7,9 @@ declare module '#auth-utils' {
     }
 
     interface UserSession {
-        // Add your own fields
+        // Id of the matching row in the `sessions` table (server/database/schema.ts).
+        // Lets requireAuth validate/revoke this specific device against the DB.
+        sessionId?: string;
     }
 }
 


### PR DESCRIPTION
## Summary
- Replaces the browser-session cookie (no `maxAge`, so users had to re-login on every visit) with a 30-day sliding session backed by a per-device row in the `sessions` table.
- `requireAuth` now validates every request against that row — 401 + cookie clear if the device was revoked or the session expired — and extends it after a day of activity.
- Users can log in on phone and desktop at the same time, see connected devices under Réglages, and end any session remotely without affecting the others.
- Also includes two smaller fixes already on this branch: category-ownership verification on expense create/update, and a fix for the custom 404 calculator crashing on empty inputs.

## Why
User wanted to stop re-authenticating on every visit, without weakening security or losing the ability to review/revoke access per device.

## What a reviewer should know
- Users currently logged in will be signed out once after this deploys — their existing cookie predates the `sessionId` field, so `requireAuth` rejects it and they just log back in normally.
- `requireAuth` now does one extra DB read per authenticated request (session lookup) and, once a day per device, one write to slide the expiry — acceptable at this app's scale.
- Migration `0002_add_session_device_tracking.sql` also picks up a pre-existing, already-live schema drift (`categories.max_budget`) that had never been captured in a migration file; unrelated to this change but bundled in since `drizzle-kit generate` diffs against the last snapshot.

## Test plan
- [x] Registered a user, confirmed a session row is created with device info.
- [x] Verified `/api/user/sessions` lists the row and marks it `current`.
- [x] Simulated a second device via a separate cookie jar (curl) — both sessions coexist independently.
- [x] Revoked device A's session from device B — confirmed device A gets an immediate 401 with cookie cleared on its next request, device B stays logged in.
- [x] Logged out via the sidebar button — confirmed the DB row is cleaned up (via the `sessionHooks` clear hook).
- [ ] `npx nuxt typecheck` — currently broken in this environment for an unrelated reason (npx pulls an incompatible vue-tsc/typescript combo; not caused by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)